### PR TITLE
Refactor the library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "stockfighter-sdk-rs"
 version = "0.0.1"
 dependencies = [
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -237,15 +237,6 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "serde_json"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ name = "stockfighter"
 [dependencies]
 
 hyper = "*"
-serde_json = "*"
+rustc-serialize = "0.3.16"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,76 +1,171 @@
 #[macro_use]
 extern crate hyper;
-extern crate serde_json;
+extern crate rustc_serialize;
 
 use std::io::Read;
 
 use hyper::Client;
-use hyper::header::Connection;
+use hyper::status::StatusCode;
+
+use rustc_serialize::json;
 
 header! { (XStarfighterAuthorization, "X-Starfighter-Authorization") => [String] }
 
-fn get<U: hyper::client::IntoUrl>(url: U) -> serde_json::Value {
-    // Create a client.
-    let client = Client::new();
-
-    // Creating an outgoing request.
-    let mut res = client.get(url)
-        // set a header
-        .header(Connection::close())
-        // let 'er go!
-        .send().unwrap();
-
-    // Read the Response.
-    let mut body = String::new();
-    res.read_to_string(&mut body).unwrap();
-
-    let value: serde_json::Value = serde_json::from_str(&body).unwrap();
-    value
+#[derive(RustcDecodable, RustcEncodable)]
+struct Heartbeat {
+    ok: bool,
+    error: String,
 }
 
-pub fn test_api() {
-    let value = get("https://api.stockfighter.io/ob/api/heartbeat");
-    println!("Response: {}", value.as_object().unwrap().get("ok").unwrap().as_boolean().unwrap());
+#[derive(RustcDecodable, RustcEncodable)]
+struct VenueHeartbeat {
+    ok: bool,
+    // venue is not present on error
+    venue: Option<String>,
 }
 
-pub fn venue(venue: &str) -> bool {
-    let url = format!("https://api.stockfighter.io/ob/api/venues/{}/heartbeat", venue);
-    let value = get(&url);
-    value.as_object().unwrap().get("ok").unwrap().as_boolean().unwrap()
+#[derive(RustcDecodable, RustcEncodable)]
+pub struct Quote {
+    ok: bool,
+    symbol: String,
+    venue: String,
+    bid: Option<usize>,
+    ask: Option<usize>,
+    bid_size: Option<usize>,
+    ask_size: Option<usize>,
+    bid_depth: Option<usize>,
+    ask_depth: Option<usize>,
+    last: usize,
+    last_size: Option<usize>,
+    last_trade: Option<String>,
+    quote_time: Option<String>,
 }
 
-pub fn quote(venue: &str, stock: &str) -> bool {
-
-    let url = format!("https://api.stockfighter.io/ob/api/venues/{}/stocks/{}/quote", venue, stock);
-
-    let client = Client::new();
-
-    let mut res = client
-        .get(&url)
-        .header(XStarfighterAuthorization("b6eb6d0a2b606c02c8b027fca35383fb2dc741d3".to_owned()))
-        .send()
-        .unwrap();
-
-    let mut body = String::new();
-    res.read_to_string(&mut body).unwrap();
-
-    let value: serde_json::Value = serde_json::from_str(&body).unwrap();
-    value.as_object().unwrap().get("ok").unwrap().as_boolean().unwrap()
+#[derive(Debug, PartialEq, Eq)]
+pub enum StockfighterError {
+    ApiDown,
+    VenueDown(String),
+    ApiError
 }
+
+pub struct Stockfighter {
+    api_key: String,
+}
+
+impl Stockfighter {
+
+    pub fn new<S>(api_key: S) -> Stockfighter where S: Into<String> {
+        Stockfighter { api_key: api_key.into() }
+    }
+
+    ///
+    /// Check that the Stockfighter API is up
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use stockfighter::Stockfighter;
+    ///
+    /// let sf = Stockfighter::new("fake api key");
+    /// assert_eq!(true, sf.heartbeat().is_ok());
+    /// ```
+    pub fn heartbeat(&self) -> Result<(), StockfighterError> {
+        let client = Client::new();
+        let mut res = client
+            .get("https://api.stockfighter.io/ob/api/heartbeat")
+            .send()
+            .unwrap();
+
+        if res.status != StatusCode::Ok {
+            return Err(StockfighterError::ApiDown);
+        }
+
+        let mut body = String::new();
+        res.read_to_string(&mut body).unwrap();
+
+        let hb: Heartbeat = json::decode(&body).unwrap();
+
+        match hb.ok {
+            true => Ok(()),
+            false => Err(StockfighterError::ApiDown)
+        }
+    }
+
+    pub fn venue_heartbeat(&self, venue: &str) -> Result<(), StockfighterError> {
+        let url = format!("https://api.stockfighter.io/ob/api/venues/{}/heartbeat", venue);
+        let client = Client::new();
+        let mut res = client
+            .get(&url)
+            .send()
+            .unwrap();
+
+        if res.status != StatusCode::Ok {
+            return Err(StockfighterError::VenueDown(venue.to_owned()));
+        }
+
+        let mut body = String::new();
+        res.read_to_string(&mut body).unwrap();
+
+        let hb: VenueHeartbeat = json::decode(&body).unwrap();
+
+        match hb.ok {
+            true => Ok(()),
+            false => Err(StockfighterError::VenueDown(venue.to_owned()))
+        }
+    }
+
+    pub fn quote(&self, venue: &str, stock: &str) -> Result<Quote, StockfighterError> {
+
+        let url = format!("https://api.stockfighter.io/ob/api/venues/{}/stocks/{}/quote", venue, stock);
+
+        let client = Client::new();
+
+        let mut res = client
+            .get(&url)
+            .header(XStarfighterAuthorization(self.api_key.clone())) // TODO fix the use of clone here
+            .send()
+            .unwrap();
+
+        if res.status != StatusCode::Ok {
+            return Err(StockfighterError::ApiError);
+        }
+
+        let mut body = String::new();
+        res.read_to_string(&mut body).unwrap();
+
+        let quote: Quote = json::decode(&body).unwrap();
+
+        match quote.ok {
+            true => Ok(quote),
+            false => Err(StockfighterError::ApiError)
+        }
+    }
+}
+
 
 #[cfg(test)]
 mod test {
     use super::*;
 
+    #[test]
+    fn test_heartbeat() {
+        let sf = Stockfighter::new("");
+        assert_eq!(true, sf.heartbeat().is_ok());
+    }
 
     #[test]
     fn test_venue() {
-        assert_eq!(true, venue("TESTEX"));
-        assert_eq!(false, venue("INVALID"));
+        let sf = Stockfighter::new("");
+        assert_eq!(true, sf.venue_heartbeat("TESTEX").is_ok());
+        assert_eq!(StockfighterError::VenueDown("INVALID".to_owned()), sf.venue_heartbeat("INVALID").unwrap_err());
     }
 
     #[test]
     fn test_quote() {
-        assert_eq!(true, quote("TESTEX", "FOOBAR"));
+        let sf = Stockfighter::new("");
+        assert_eq!(true, sf.quote("TESTEX", "FOOBAR").is_ok());
+        assert_eq!(true, sf.quote("INVALID", "FOOBAR").is_err());
+        assert_eq!(true, sf.quote("TESTEX", "INVALID").is_err());
+        assert_eq!(true, sf.quote("INVALID", "INVALID").is_err());
     }
 }


### PR DESCRIPTION
- use a `Stockfighter` object
- use rustc_serialize instead of serde
- deserialize responses into structs
- properly handle non-200 http response codes
- use `Result` return type for API calls
- show how to document methods